### PR TITLE
目次をレベル２までに制限するように設定を追加

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["intopic-toc"]
+}


### PR DESCRIPTION
> intopic-toc
> 右上に目次を表示します．標準では見出しレベル２のものが表示されます．

http://mebiusbox.github.io/contents/gitbook/src/navigator.html

一応問題ない想定ですが、
実際に入れてみて他の設定も追加で必要となるのかは
試しに入れてみて検証していく形になるかと思います。